### PR TITLE
Fix typo in ecosystem Dockerfile on line 67, change # to $

### DIFF
--- a/ecosystem/Dockerfile
+++ b/ecosystem/Dockerfile
@@ -64,7 +64,7 @@ RUN curl http://ftp.unicamp.br/pub/apache/flume/${FLUME_VERSION}/apache-flume-${
 ADD flume-env.sh /opt/flume/conf/flume-env.sh
 ENV FLUME_HOME=/opt/flume
 ENV PATH=$PATH:$FLUME_HOME/bin
-ENV CLASSPATH=#CLASSPATH:$FLUME_HOME/lib/*
+ENV CLASSPATH=$CLASSPATH:$FLUME_HOME/lib/*
 
 # Mahout
 ENV MAHOUT_VERSION 0.12.2


### PR DESCRIPTION
Hi - Ran into some java class issues with this and noticed that there was a # instead of $ in the CLASSPATH environment variable.
Thanks,
Mark